### PR TITLE
Remove duplicative "Correct" statements and correct minor typos

### DIFF
--- a/chapters/chapter1.md
+++ b/chapters/chapter1.md
@@ -40,7 +40,7 @@ A classification model predicts a group membership or discrete class label, not 
 
 <opt text="Regression" correct="true">
 
-Correct! 👏 To predict a continuous, numeric quantity like fuel efficiency, use regression models.
+👏 To predict a continuous, numeric quantity like fuel efficiency, use regression models.
 
 </opt>
 </choice>
@@ -49,7 +49,7 @@ Correct! 👏 To predict a continuous, numeric quantity like fuel efficiency, us
 
 <exercise id="3" title="Visualizing the fuel efficiency distribution">
 
-The first step before you start modeling is to explore your data. In this course we'll practice using tidyverse functions for exploratory data analysis. Start off this case study by examinign your data set and visualizing the distribution of fuel efficiency. The ggplot2 package, with functions like [`ggplot()`](https://ggplot2.tidyverse.org/reference/ggplot.html) and [`geom_histogram()`](https://ggplot2.tidyverse.org/reference/geom_histogram.html) are included in the tidyverse.
+The first step before you start modeling is to explore your data. In this course we'll practice using tidyverse functions for exploratory data analysis. Start off this case study by examining your data set and visualizing the distribution of fuel efficiency. The ggplot2 package, with functions like [`ggplot()`](https://ggplot2.tidyverse.org/reference/ggplot.html) and [`geom_histogram()`](https://ggplot2.tidyverse.org/reference/geom_histogram.html) are included in the tidyverse.
 
 **Instructions**
 

--- a/chapters/chapter2.md
+++ b/chapters/chapter2.md
@@ -34,7 +34,7 @@ Clustering is an example of unsupervised machine learning, which we will not cov
 
 <opt text="Classification" correct="true">
 
-Correct! To predict group membership or discrete class labels, use classification models.
+To predict group membership or discrete class labels, use classification models.
 
 </opt>
 
@@ -49,7 +49,7 @@ A regression model predicts a numeric/continuous value or response, not a group 
 
 <exercise id="3" title="Exploring the Stack Overflow survey">
 
-Anytime you are planning to implement modeling, it is always a good idea to explore your dataset. Start off this modeling analysis by checking out how many remote and non-remote developers have to work with, where they live, and how much experience they have.
+Anytime you are planning to implement modeling, it is always a good idea to explore your dataset. Start off this modeling analysis by checking out how many remote and non-remote developers you have to work with, where they live, and how much experience they have.
 
 **Instructions**
 
@@ -165,7 +165,7 @@ Although there were more non-remote developers in the original dataset, upsampli
 
 <opt text="There are the same number of remote and non-remote developers." correct="true">
 
-Correct! Upsampling samples with replacement until the class distributions are equal, so there are the same number of remote and non-remote developers after upsampling.
+Upsampling samples with replacement until the class distributions are equal, so there are the same number of remote and non-remote developers after upsampling.
 
 </opt>
 
@@ -186,7 +186,7 @@ We used upsampling only on a subset of the data, because its purpose is only app
 
 <opt text="The training data." correct="true">
 
-Correct! ⭐️ Adjusting class imbalance helps you train a model that performs better.
+⭐️ Adjusting class imbalance helps you train a model that performs better.
 
 </opt>
 

--- a/chapters/chapter3.md
+++ b/chapters/chapter3.md
@@ -34,7 +34,7 @@ Clustering is an example of unsupervised machine learning, which we will not cov
 
 <opt text="Classification" correct="true">
 
-Correct! To predict group membership or discrete class labels, use classification models.
+To predict group membership or discrete class labels, use classification models.
 
 </opt>
 
@@ -101,7 +101,7 @@ This is real data from the real world, so you need to think through important mo
 <choice>
 <opt text="This data set is imbalanced." correct="true">
 
-Correct! There are over 20 times more people in this survey who said they did vote than who said they did not.
+There are over 20 times more people in this survey who said they did vote than who said they did not.
 
 </opt>
 
@@ -199,7 +199,7 @@ If you divide your data into 50 subsets, that would be called 50-fold cross-vali
 
 <opt text="randomly divide your training data into 10 subsets and train on 9 at a time (validating on the other subset), iterating through all 10 subsets for validation. Then you repeat that process 5 times." correct="true">
 
-Correct! ⚡️ Simulations and practical experience show that 10-fold cross-validation repeated 5 times is a great resampling approach for many situations. This approach involves randomly dividing your training data into 10 folds, or subsets or groups, and training on only 9 while using the other fold for validation. You iterate through all 10 folds being used for validation; this is one round of cross-validation. You can then repeat the whole process multiple, perhaps 5, times.
+⚡️ Simulations and practical experience show that 10-fold cross-validation repeated 5 times is a great resampling approach for many situations. This approach involves randomly dividing your training data into 10 folds, or subsets or groups, and training on only 9 while using the other fold for validation. You iterate through all 10 folds being used for validation; this is one round of cross-validation. You can then repeat the whole process multiple, perhaps 5, times.
 
 </opt>
 
@@ -324,7 +324,7 @@ Random forest models are very powerful and the random forest model had higher ac
 
 <opt text="Logistic regression" correct="true">
 
-Correct! Logistic regression is a simpler model, but in this case, it performed better on the testing data and you can expect it to do a better job predicting on new data.
+Logistic regression is a simpler model, but in this case, it performed better on the testing data and you can expect it to do a better job predicting on new data.
 
 </opt>
 </choice>

--- a/chapters/chapter4.md
+++ b/chapters/chapter4.md
@@ -40,7 +40,7 @@ A classification model predicts a group membership or discrete class label, not 
 
 <opt text="Regression" correct="true">
 
-Correct! To predict a continuous, numeric quantity like age, use regression models.
+To predict a continuous, numeric quantity like age, use regression models.
 
 </opt>
 </choice>
@@ -178,7 +178,7 @@ Training is done with the training set.
 
 <opt text="compare models you have trained and choose which one to use." correct="true">
 
-Correct! A validation test is used to compare models or tune hyperparameters.
+A validation test is used to compare models or tune hyperparameters.
 
 </opt>
 

--- a/slides/chapter4_10.md
+++ b/slides/chapter4_10.md
@@ -38,7 +38,7 @@ sisters_xg <- train(age ~ ., method = "xgbLinear", data = sisters_train)
 sisters_gbm <- train(age ~ ., method = "gbm", data = sisters_train)
 ```
 
-Notes: You will use your training dataset when you train the models, as you have throughout this course. In the other case studies, we stuck with just two kinds of models and didn't explore a lot of ways to tune them. We trained the models using the training set, and then tested them using the testing test. 
+Notes: You will use your training dataset when you train the models, as you have throughout this course. In the other case studies, we stuck with just two kinds of models and didn't explore a lot of ways to tune them. We trained the models using the training set, and then tested them using the testing set. 
 
 If you stop 🛑 to think about what we were doing when we used the test set, though, you'll realize there is more than one thing going on. We looked at model performance on the test set, decided which model was best, and then assumed that same model performance would apply to new data.
 


### PR DESCRIPTION
Thanks for creating this; it’s well-designed and written!

As I went through the chapters, I noted that the correct responses to the mini-quiz questions already began with “That’s Correct!”, so the “Correct!” text in the chapter files was duplicative. This PR removes the duplicative “Correct!”s and resolves a few very minor typos I saw as I went through it.

I realize there’s a good chance you may be revamping this to move from carat to parsnip in the near future, but I figured no harm done by practicing my PR skills in an extremely minor way.

Thanks again! I learned a lot.