### PR TITLE
Chg 'upsample' to 'downsample' in Ch2 quiz

### DIFF
--- a/chapters/chapter2.md
+++ b/chapters/chapter2.md
@@ -172,7 +172,7 @@ Downsampling removes from the majority class until the class distributions are e
 
 <exercise id="9" title="Downsampling in your workflow">
 
-We are starting to add more steps into the machine learning workflow. Think about when we implemented downsampling to deal with class imbalance. Which data set did we upsample?
+We are starting to add more steps into the machine learning workflow. Think about when we implemented downsampling to deal with class imbalance. Which data set did we downsample?
 
 <choice>
 <opt text="The original data.">


### PR DESCRIPTION
Hi @juliasilge -- I was looking at the `tidymodels` rewrite of your great course and noticed a small typo. This PR changes "upsample" to "downsample" in a Chapter 2 quiz question. Thanks so much to you and the `tidymodels` team on all the great new resources you're releasing! 